### PR TITLE
Sarah remove mentors contact

### DIFF
--- a/mentors.html
+++ b/mentors.html
@@ -492,7 +492,7 @@
                   <div class="infobox-header">Shift info:</div>
                   <div>2pm - 9pm Sat</div>
                 </div>
-              </div>>
+              </div>
             </div>
           </div>
         </div>

--- a/mentors.html
+++ b/mentors.html
@@ -102,14 +102,6 @@
                   <div>2pm - 9pm Sat</div>
                 </div>
               </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div>jaronoff@drift.com</div>
-                  <div><a href="https://acmeco.slack.com/team/UTJGP3FK2" target="_blank">Message Me on slack</a></div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -137,14 +129,6 @@
                 <div class="mentor-infobox col-6">
                   <div class="infobox-header">Shift info:</div>
                   <div>10am - 2pm Sat</div>
-                </div>
-              </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div><a href="https://acmeco.slack.com/team/UTLHUG0NS" target="_blank">Message Me on Slack</a></div>
-                  <div>callan@drift.com</div>
                 </div>
               </div>
             </div>
@@ -175,13 +159,6 @@
                 <div class="mentor-infobox col-6">
                   <div class="infobox-header">Shift info:</div>
                   <div>10am - 2pm Sat</div>
-                </div>
-              </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div>pqtemplin@gmail.com</div>
                 </div>
               </div>
             </div>
@@ -215,13 +192,6 @@
                   <div>8am - 10am Sun</div>
                 </div>
               </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div>rmorris@drift.com</div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -249,14 +219,6 @@
                   <div class="infobox-header">Shift info:</div>
                   <div>9pm - 12am Fri</div>
                   <div>2pm - 6pm Sat</div>
-                </div>
-              </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div><a href="https://acmeco.slack.com/team/UTC51R6LR" target="_blank">Message Me on Slack</a></div>
-                  <div>vkgregorchik@gmail.com</div>
                 </div>
               </div>
             </div>
@@ -291,14 +253,6 @@
                   <div>10am - 6pm Sat</div>
                 </div>
               </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div><a href="https://acmeco.slack.com/team/UTBQ5PG65" target="_blank">Message Me on Slack</a></div>
-                  <div>scott.batson@upstatement.com</div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -328,13 +282,6 @@
                   <div class="infobox-header">Shift info:</div>
                   <div>9pm - 12am Fri</div>
                   <div>8am - 10am Sun</div>
-                </div>
-              </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div>bea@upstatement.com</div>
                 </div>
               </div>
             </div>
@@ -368,13 +315,6 @@
                   <div>6pm - 12am Sat</div>
                 </div>
               </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div>michael.pelletier@upstatement.com</div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -402,14 +342,6 @@
                   <div class="infobox-header">Shift info:</div>
                   <div>9pm - 12am Fri</div>
                   <div>8am - 10am Sun</div>
-                </div>
-              </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div><a href="https://acmeco.slack.com/team/UTN9XM3LL" target="_blank">Message Me on Slack</a></div>
-                  <div>alec@alecmarc.us</div>
                 </div>
               </div>
             </div>
@@ -445,14 +377,6 @@
                   <div>10am - 2pm Sat</div>
                 </div>
               </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div><a href="https://acmeco.slack.com/team/UTLA8K6KY" target="_blank">Message Me on Slack</a></div>
-                  <div>ryan.baker@singularity.energy</div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -480,14 +404,6 @@
                   <div class="infobox-header">Shift info:</div>
                   <div>9pm - 12am Fri</div>
                   <div>9pm - 12am Sat</div>
-                </div>
-              </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div><a href="https://acmeco.slack.com/team/UTQDG3GDV" target="_blank">Message Me on Slack</a></div>
-                  <div>gllevy@gmail.com</div>
                 </div>
               </div>
             </div>
@@ -519,14 +435,6 @@
                   <div>6pm - 9pm Sat</div>
                 </div>
               </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div><a href="https://acmeco.slack.com/team/UT845KEJD" target="_blank">Message Me on Slack</a></div>
-                  <div>iyudkovich@kyruus.com</div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -552,14 +460,6 @@
                   <div class="infobox-header">Shift info:</div>
                   <div>9pm - 12am Fri</div>
                   <div>10am - 2pm Sat</div>
-                </div>
-              </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div><a href="https://acmeco.slack.com/team/UT59SEH26" target="_blank">Message Me on Slack</a></div>
-                  <div>johnlgervasi@gmail.com</div>
                 </div>
               </div>
             </div>
@@ -592,14 +492,7 @@
                   <div class="infobox-header">Shift info:</div>
                   <div>2pm - 9pm Sat</div>
                 </div>
-              </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div>petersomers2@gmail.com</div>
-                </div>
-              </div>
+              </div>>
             </div>
           </div>
         </div>
@@ -629,14 +522,6 @@
                   <div class="infobox-header">Shift info:</div>
                   <div>9pm - 12am Fri</div>
                   <div>8am - 10am Sun</div>
-                </div>
-              </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div><a href="https://acmeco.slack.com/team/UTLKAHLBA" target="_blank">Message Me on Slack</a></div>
-                  <div>aaron.elliot@logmein.com</div>
                 </div>
               </div>
             </div>
@@ -670,13 +555,6 @@
                   <div>9pm - 12am Fri</div>
                 </div>
               </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div>proneel.gupta@poweradvocate.com</div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -707,13 +585,6 @@
                   <div>10am - 2pm Sat</div>
                 </div>
               </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div>william.guo@poweradvocate.com</div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -739,13 +610,6 @@
                 <div class="mentor-infobox col-6">
                   <div class="infobox-header">Shift info:</div>
                   <div>6pm - 12am Sat</div>
-                </div>
-              </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div>ajenkins@kyruus.com</div>
                 </div>
               </div>
             </div>
@@ -779,14 +643,6 @@
                   <div>2pm - 9pm Sat</div>
                 </div>
               </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div><a href="https://acmeco.slack.com/team/UTNG2TMM5" target="_blank">Message Me on Slack</a></div>
-                  <div>plynch@kyruus.com</div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -814,14 +670,6 @@
                   <div class="infobox-header">Shift info:</div>
                   <div>9pm - 12am Fri</div>
                   <div>2pm - 6pm Sat</div>
-                </div>
-              </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div><a href="https://acmeco.slack.com/team/UTSHXMP70" target="_blank">Message Me on Slack</a></div>
-                  <div>ean.moody@pathai.com</div>
                 </div>
               </div>
             </div>
@@ -852,13 +700,6 @@
                   <div>9pm - 12am Fri</div>
                 </div>
               </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div>matt.coleman@pathai.com</div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -885,13 +726,6 @@
                   <div>9pm - 12am Sat</div>
                 </div>
               </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div>grodin.robby@gmail.com</div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -916,13 +750,6 @@
                 <div class="mentor-infobox col-6">
                   <div class="infobox-header">Shift info:</div>
                   <div>10am - 2pm Sat</div>
-                </div>
-              </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div>david.dantonio@pathai.com</div>
                 </div>
               </div>
             </div>
@@ -955,13 +782,6 @@
                   <div>2pm - 6pm Sat</div>
                 </div>
               </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div>evanscribner1@gmail.com</div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -991,13 +811,6 @@
                 <div class="mentor-infobox col-6">
                   <div class="infobox-header">Shift info:</div>
                   <div>10am - 2pm Sat</div>
-                </div>
-              </div>
-
-              <div class="row">
-                <div class="contact-info col-12">
-                  <div class="infobox-header">Contact info:</div>
-                  <div>tkowalski@drift.com</div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
One of the mentors messaged Ashna to ask that their contact info be taken down from the day-of site (they said they thought they were getting spam from it). I think it makes sense to take down others' contact info too, since we don't really need it there any more. 

This is what the page looks like without it: 
![image](https://user-images.githubusercontent.com/23193756/88436581-8f58a900-cdd2-11ea-9220-bb77d9bf2ca2.png)
